### PR TITLE
Burst Trie sometimes returns wrong values 

### DIFF
--- a/btrie/btrie.h
+++ b/btrie/btrie.h
@@ -13,6 +13,7 @@ template <class KeyType, class ValueType, class TopStruct, class UpdateLeafBucke
     typedef typename KeyInfo::BitIdx BitIdx;
     typedef typename TopStruct::Leaf Leaf;
     typedef typename TopStruct::INode INode;
+    typedef /*unsigned short*/unsigned int ChildIdx;
 
     TopStruct& top_struct;
     int bucket_size;
@@ -56,7 +57,7 @@ template <class KeyType, class ValueType, class TopStruct, class UpdateLeafBucke
                 fb = b;
             }
             Leaf* l = new Leaf(key, b);
-            parent->add_leaf(l, leaf_idx);
+            parent->add_leaf(l, (ChildIdx)leaf_idx);
 
             update_mem_counter<count_mem,Bucket>(MemCounter::NEW, b);
             update_mem_counter<count_mem,Leaf>(MemCounter::NEW, l);

--- a/bucket_structs/sorted_bucket.h
+++ b/bucket_structs/sorted_bucket.h
@@ -10,6 +10,8 @@
 template <class KeyType, class ValueType, bool count_mem = false> class SortedBucket
 {
 public:
+    typedef /*unsigned short*/unsigned int ChildIdx;
+
     int num_elems, capacity, max_capacity;
     SortedBucket* prev;
     SortedBucket* next;
@@ -209,7 +211,7 @@ public:
     {
         const KeyType& k = keys[0];
         const KeyType& v = values[0];
-        int idx = KeyTypeInfo<KeyType>::extract_bits(k, shift, length);
+        int idx = (ChildIdx)KeyTypeInfo<KeyType>::extract_bits(k, shift, length);
         SortedBucket* first_new = new SortedBucket<KeyType,ValueType,count_mem>(k, v, INITIAL_CAPACITY, max_capacity);
         update_mem_counter<count_mem,SortedBucket>(MemCounter::NEW, first_new);
         if(prev)
@@ -226,7 +228,7 @@ public:
         {
             const KeyType& k = keys[i];
             const KeyType& v = values[i];
-            int idx = KeyTypeInfo<KeyType>::extract_bits(k, shift, length);
+            int idx = (ChildIdx)KeyTypeInfo<KeyType>::extract_bits(k, shift, length);
             if(!node->leaves[idx])
             {
                 SortedBucket* b_new = new SortedBucket<KeyType,ValueType,count_mem>(k, v, INITIAL_CAPACITY, max_capacity);

--- a/bucket_structs/sorted_bucket.h
+++ b/bucket_structs/sorted_bucket.h
@@ -313,8 +313,12 @@ public:
     ValueType* locate_with_list(const KeyType& key)
     {
         if(key < keys[0]) {
-            return prev->locate_with_list(key);
-        } else { 
+            if (prev==nullptr) {
+                return nullptr;
+            } else {
+                return prev->locate_with_list(key);
+            }
+        } else {
             auto it = std::upper_bound(keys, keys + num_elems, key);
             return (ValueType*)(--it);
         }

--- a/bucket_structs/sorted_bucket.h
+++ b/bucket_structs/sorted_bucket.h
@@ -209,8 +209,8 @@ public:
     }
     template <class INode, class Leaf> SortedBucket* burst_into(INode* node, Leaf*, int shift, int length)
     {
-        const KeyType& k = keys[0];
-        const KeyType& v = values[0];
+        const KeyType& k = (KeyType)keys[0];
+        const KeyType& v = (KeyType)values[0];
         int idx = (ChildIdx)KeyTypeInfo<KeyType>::extract_bits(k, shift, length);
         SortedBucket* first_new = new SortedBucket<KeyType,ValueType,count_mem>(k, v, INITIAL_CAPACITY, max_capacity);
         update_mem_counter<count_mem,SortedBucket>(MemCounter::NEW, first_new);
@@ -226,8 +226,8 @@ public:
         SortedBucket* b = first_new;
         for(int i = 1; i < num_elems; i++)
         {
-            const KeyType& k = keys[i];
-            const KeyType& v = values[i];
+            const KeyType& k = (KeyType)keys[i];
+            const KeyType& v = (KeyType)values[i];
             int idx = (ChildIdx)KeyTypeInfo<KeyType>::extract_bits(k, shift, length);
             if(!node->leaves[idx])
             {
@@ -316,7 +316,7 @@ public:
             return prev->locate_with_list(key);
         } else { 
             auto it = std::upper_bound(keys, keys + num_elems, key);
-            return (--it);
+            return (ValueType*)(--it);
         }
     }
     inline ValueType* get_max_value_ptr()


### PR DESCRIPTION
Hi, 
Johannes Fischer, Patrick Dinklage and I worked on dynamic predecesor data structures and included the burst trie into our benchmark. It will be published at SEA 2021 and a preprint is available here: https://arxiv.org/abs/2104.06740

The burst tries sometimes returned wrong values. This happened, because in some cases the predecessor value was not in the current bucket, but in the previous one.
